### PR TITLE
Fix creation of instruments from GUI

### DIFF
--- a/instrument_plugins/Remote_Instrument.py
+++ b/instrument_plugins/Remote_Instrument.py
@@ -45,15 +45,15 @@ class Remote_Instrument(Instrument):
         if argspec is None:
             codestr = 'lambda *args, **kwargs: self._call("%s", *args, **kwargs)' % funcname
         else:
-            if len(argspec['args']) < 1:
+            if len(argspec.args) < 1:
                 args = ''
             else:
-                args = ','.join(argspec['args'][1:])
+                args = ','.join(argspec.args[1:])
 
-            if argspec['varargs'] is not None:
-                args = self._extend_args(args, '*%s' % argspec['varargs'])
-            if argspec['keywords'] is not None:
-                args = self._extend_args(args, '**%s' % argspec['keywords'])
+            if argspec.varargs is not None:
+                args = self._extend_args(args, '*%s' % argspec.varargs)
+            if argspec.keywords is not None:
+                args = self._extend_args(args, '**%s' % argspec.keywords)
             else:
                 args = self._extend_args(args, '**kwargs')
 

--- a/source/instrument.py
+++ b/source/instrument.py
@@ -1050,9 +1050,6 @@ class Instrument(SharedGObject):
         p['value'] = value
         self._queue_changed({name: value})
 
-    def get_argspec_dict(self, a):
-        return dict(args=a[0], varargs=a[1], keywords=a[2], defaults=a[3])
-
     def add_function(self, name, **options):
         '''
         Inform the Instrument wrapper class to expose a function.
@@ -1069,7 +1066,7 @@ class Instrument(SharedGObject):
         if hasattr(f, '__doc__'):
             options['doc'] = getattr(f, '__doc__')
 
-        options['argspec'] = self.get_argspec_dict(inspect.getargspec(f))
+        options['argspec'] = inspect.getargspec(f)
 
         self._functions[name] = options
 

--- a/source/lib/gui/frontpanel.py
+++ b/source/lib/gui/frontpanel.py
@@ -331,8 +331,8 @@ class FrontPanel(qtwindow.QTWindow):
         rows = self._table.props.n_rows
         functions = self._instrument.get_functions()
         for fname, fopts in dict_to_ordered_tuples(functions):
-            anames = fopts['argspec']['args']
-            adefaults = fopts['argspec']['defaults']
+            anames = fopts['argspec'].args
+            adefaults = fopts['argspec'].defaults
             for i, aname in enumerate(anames):
                 if aname == 'self':
                     continue

--- a/source/lib/gui/functionframe.py
+++ b/source/lib/gui/functionframe.py
@@ -46,8 +46,8 @@ class ArgumentTable(gtk.Table):
         if argspec is None:
             return
 
-        names = argspec['args']
-        defaults = argspec['defaults']
+        names = argspec.args
+        defaults = argspec.defaults
         for i, name in enumerate(names):
             if name in self._exclude:
                 continue


### PR DESCRIPTION
Since Python 2.6, inspect.getargspec returns a NamedTuple and no more a simple tuple

Adapt the code to handle new behaviour and thus fix creation of new instruments from GUI
